### PR TITLE
fix: add package-lock to package to remove unity warnings

### DIFF
--- a/package.json
+++ b/package.json
@@ -126,6 +126,7 @@
         {
           "assets": [
             "package.json",
+            "package-lock.json",
             "CHANGELOG.md"
           ],
           "message": "chore(release): ${nextRelease.version} [skip ci]\n\n${nextRelease.notes}"


### PR DESCRIPTION
When using this package, on startup unity throws a warning about having a meta file which does not have a matching file, and that it cannot delete the file due to being in an immutable folder.
This should prevent that warning from occuring