### PR TITLE
Fixed object reference duplicate in arrays #19

### DIFF
--- a/Editor/Drawers/RawReferenceDrawer.cs
+++ b/Editor/Drawers/RawReferenceDrawer.cs
@@ -121,7 +121,7 @@ namespace TNRD.Drawers
 
             if (previousReferenceValue == currentReferenceValue)
             {
-                rawReferenceProperty.managedReferenceValue = CreateInstance(currentReferenceValue);
+                RawReferenceValue = CreateInstance(currentReferenceValue);
                 rawReferenceProperty.serializedObject.ApplyModifiedProperties();
             }
 

--- a/Editor/Drawers/RawReferenceDrawer.cs
+++ b/Editor/Drawers/RawReferenceDrawer.cs
@@ -11,6 +11,9 @@ namespace TNRD.Drawers
         private readonly GUIContent label;
         private readonly FieldInfo fieldInfo;
 
+        private static object previousReferenceValue;
+        private static string previousPropertyPath;
+
         private object RawReferenceValue
         {
             get
@@ -21,6 +24,15 @@ namespace TNRD.Drawers
                 ISerializableInterface instance =
                     (ISerializableInterface)fieldInfo.GetValue(Property.serializedObject.targetObject);
                 return instance.GetRawReference();
+#endif
+            }
+
+            set
+            {
+#if UNITY_2021_1_OR_NEWER
+                RawReferenceProperty.managedReferenceValue = value;
+#else
+                fieldInfo.SetValue(Property.serializedObject.targetObject, value);
 #endif
             }
         }
@@ -47,6 +59,8 @@ namespace TNRD.Drawers
         /// <inheritdoc />
         public void OnGUI(Rect position)
         {
+            AvoidDuplicateReferencesInArray();
+
             Rect objectFieldRect = new Rect(position)
             {
                 height = EditorGUIUtility.singleLineHeight
@@ -71,6 +85,8 @@ namespace TNRD.Drawers
                 true);
 
             HandleDragAndDrop(objectFieldRect);
+
+            previousPropertyPath = Property.propertyPath;
         }
 
         /// <inheritdoc />
@@ -90,6 +106,38 @@ namespace TNRD.Drawers
                     return;
                 }
             }
+        }
+
+        private void AvoidDuplicateReferencesInArray()
+        {
+            if (!IsPropertyInArray(Property)) return;
+            if (previousPropertyPath == null) return;
+            if (previousPropertyPath == Property.propertyPath) return;
+
+            var rawReferenceProperty = Property.FindPropertyRelative("rawReference");
+            var currentReferenceValue = RawReferenceValue;
+
+            if (currentReferenceValue == null) return;
+
+            if (previousReferenceValue == currentReferenceValue)
+            {
+                rawReferenceProperty.managedReferenceValue = CreateInstance(currentReferenceValue);
+                rawReferenceProperty.serializedObject.ApplyModifiedProperties();
+            }
+
+            previousReferenceValue = currentReferenceValue;
+        }
+
+        private static bool IsPropertyInArray(SerializedProperty prop)
+        {
+            return prop.propertyPath.Contains(".Array.data[");
+        }
+
+        private static object CreateInstance(object source)
+        {
+            var instance = Activator.CreateInstance(source.GetType());
+            EditorUtility.CopySerializedManagedFieldsOnly(source, instance);
+            return instance;
         }
     }
 }

--- a/Editor/Drawers/RawReferenceDrawer.cs
+++ b/Editor/Drawers/RawReferenceDrawer.cs
@@ -110,14 +110,18 @@ namespace TNRD.Drawers
 
         private void AvoidDuplicateReferencesInArray()
         {
-            if (!IsPropertyInArray(Property)) return;
-            if (previousPropertyPath == null) return;
-            if (previousPropertyPath == Property.propertyPath) return;
+            if (!IsPropertyInArray(Property)) 
+                return;
+            if (previousPropertyPath == null) 
+                return;
+            if (previousPropertyPath == Property.propertyPath) 
+                return;
 
-            var rawReferenceProperty = Property.FindPropertyRelative("rawReference");
-            var currentReferenceValue = RawReferenceValue;
+            SerializedProperty rawReferenceProperty = Property.FindPropertyRelative("rawReference");
+            object currentReferenceValue = RawReferenceValue;
 
-            if (currentReferenceValue == null) return;
+            if (currentReferenceValue == null) 
+                return;
 
             if (previousReferenceValue == currentReferenceValue)
             {
@@ -135,7 +139,7 @@ namespace TNRD.Drawers
 
         private static object CreateInstance(object source)
         {
-            var instance = Activator.CreateInstance(source.GetType());
+            object instance = Activator.CreateInstance(source.GetType());
             EditorUtility.CopySerializedManagedFieldsOnly(source, instance);
             return instance;
         }

--- a/Editor/SerializableInterfacePropertyDrawer.cs
+++ b/Editor/SerializableInterfacePropertyDrawer.cs
@@ -134,7 +134,7 @@ namespace TNRD
             GUIContent label
         )
         {
-            SerializedProperty modeProperty = property.FindPropertyRelative(MODE);
+            SerializedProperty modeProperty = serializedProperty.FindPropertyRelative(MODE);
             ReferenceMode referenceMode = (ReferenceMode)modeProperty.enumValueIndex;
 
             switch (referenceMode)

--- a/Editor/SerializableInterfacePropertyDrawer.cs
+++ b/Editor/SerializableInterfacePropertyDrawer.cs
@@ -10,7 +10,11 @@ namespace TNRD
     [CustomPropertyDrawer(typeof(SerializableInterface<>), true)]
     internal sealed class SerializableInterfacePropertyDrawer : PropertyDrawer
     {
+        private const string k_RawReference = "rawReference";
+
         private SerializedProperty serializedProperty;
+        private object previousReferenceValue;
+        private string lastPropertyPath;
         private Type genericType;
 
         private IReferenceDrawer activeDrawer;
@@ -23,14 +27,46 @@ namespace TNRD
 
         private void Initialize(SerializedProperty property)
         {
-            if (serializedProperty == property)
-                return;
-
-            activeDrawer = null;
             serializedProperty = property;
+            activeDrawer = null;
             genericType = GetGenericArgument();
+
             Assert.IsNotNull(genericType, "Unable to find generic argument, are you doing some shady inheritance?");
         }
+
+        /// <summary>
+        /// Avoids an unexpected behaviour
+        /// </summary>
+        private void AvoidDuplicateReferences(SerializedProperty property)
+        {
+            if (!IsTargetObjectArray(property)) return; // This function 
+            if (lastPropertyPath == null) return;
+            if (lastPropertyPath == property.propertyPath) return; // only one element
+
+            var rawReferenceProperty = property.FindPropertyRelative(k_RawReference); // Cache property
+            var currentReferenceValue = rawReferenceProperty.managedReferenceValue;
+
+            if (currentReferenceValue == null) return; // Value is null. Probably new or not set yet
+
+            if (previousReferenceValue == currentReferenceValue)
+            {
+                // The best behaviour would be to create a shallow copy. The extension method from SolidUtilities works perfectly.
+                // Using serialization or reflection might also work
+                var instance = Activator.CreateInstance(currentReferenceValue.GetType());
+                rawReferenceProperty.managedReferenceValue = instance;
+
+                // propertyRelative.managedReferenceValue = currentReferenceValue.ShallowCopy();
+            }
+
+            previousReferenceValue = currentReferenceValue;
+        }
+
+
+        private static bool IsTargetObjectArray(SerializedProperty prop)
+        {
+            return prop.propertyPath.Contains(".Array.data[");
+        }
+
 
         /// <inheritdoc />
         public override float GetPropertyHeight(SerializedProperty property, GUIContent label)
@@ -44,8 +80,12 @@ namespace TNRD
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             Initialize(property);
+            AvoidDuplicateReferences(property);
+
             activeDrawer = GetReferenceDrawer(activeDrawer, property, label);
             activeDrawer.OnGUI(position);
+
+            lastPropertyPath = property.propertyPath;
         }
 
         private Type GetGenericArgument()

--- a/Editor/SerializableInterfacePropertyDrawer.cs
+++ b/Editor/SerializableInterfacePropertyDrawer.cs
@@ -10,16 +10,10 @@ namespace TNRD
     [CustomPropertyDrawer(typeof(SerializableInterface<>), true)]
     internal sealed class SerializableInterfacePropertyDrawer : PropertyDrawer
     {
-        private const string RAW_REFERENCE = "rawReference";
-        private const string MODE = "mode";
-
         private SerializedProperty serializedProperty;
         private Type genericType;
 
         private IReferenceDrawer activeDrawer;
-
-        private object previousReferenceValue;
-        private string previousPropertyPath;
 
         /// <inheritdoc />
         public override bool CanCacheInspectorGUI(SerializedProperty property) => false;
@@ -48,48 +42,8 @@ namespace TNRD
         public override void OnGUI(Rect position, SerializedProperty property, GUIContent label)
         {
             Initialize(property);
-            AvoidDuplicateReferencesInArray(property);
-
             activeDrawer = GetReferenceDrawer(activeDrawer, property, label);
             activeDrawer.OnGUI(position);
-            previousPropertyPath = property.propertyPath;
-        }
-
-        /// <summary>
-        /// When a new instance of <see cref="SerializableInterface{T}"/> is added in an array using the inspector's gizmo,
-        /// avoids having their <see cref="SerializableInterface{T}.rawReference"/> field reference the same instance.
-        /// </summary>
-        /// <param name="property">The SerializedProperty to make the custom GUI for.</param>
-        private void AvoidDuplicateReferencesInArray(SerializedProperty property)
-        {
-            if (!IsPropertyInArray(property)) return;
-            if (previousPropertyPath == null) return;
-            if (previousPropertyPath == property.propertyPath) return;
-
-            var rawReferenceProperty = property.FindPropertyRelative(RAW_REFERENCE);
-            var currentReferenceValue = rawReferenceProperty.managedReferenceValue;
-
-            if (currentReferenceValue == null) return;
-
-            if (previousReferenceValue == currentReferenceValue)
-            {
-                rawReferenceProperty.managedReferenceValue = CreateInstance(currentReferenceValue);
-                rawReferenceProperty.serializedObject.ApplyModifiedProperties();
-            }
-
-            previousReferenceValue = currentReferenceValue;
-        }
-        
-        private static bool IsPropertyInArray(SerializedProperty prop)
-        {
-            return prop.propertyPath.Contains(".Array.data[");
-        }
-
-        private static object CreateInstance(object source)
-        {
-            var instance = Activator.CreateInstance(source.GetType());
-            EditorUtility.CopySerializedManagedFieldsOnly(source, instance);
-            return instance;
         }
 
         private Type GetGenericArgument()
@@ -134,7 +88,7 @@ namespace TNRD
             GUIContent label
         )
         {
-            SerializedProperty modeProperty = serializedProperty.FindPropertyRelative(MODE);
+            SerializedProperty modeProperty = serializedProperty.FindPropertyRelative("mode");
             ReferenceMode referenceMode = (ReferenceMode)modeProperty.enumValueIndex;
 
             switch (referenceMode)

--- a/Editor/SerializableInterfacePropertyDrawer.cs
+++ b/Editor/SerializableInterfacePropertyDrawer.cs
@@ -26,7 +26,6 @@ namespace TNRD
             activeDrawer = null;
             serializedProperty = property;
             genericType = GetGenericArgument();
-
             Assert.IsNotNull(genericType, "Unable to find generic argument, are you doing some shady inheritance?");
         }
 


### PR DESCRIPTION
# Description

As described by the issue, when a new instance of **SerializableInterface<T>** is added in an array using the inspector's gizmo, Unity clones the last **SerializableInterface<T>**. Since rawReference is [SerializeReference], the reference of the object is copied by ref, which makes the new element references the same instance as the previous one. 

**Editing the last element will modify the previous one too.** 

This bug should only applies to pure serializable C# classes stored in the **rawReference**'s field. This is why I moved the fix from SerializableInterfacePropertyDrawer to  RawReferenceDrawer in my previous commits. 

**This fixes #19** without adding any dependencies and in an _easy-to read (ish)_ fashion.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project (added first constants, had to guess the naming convention)
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings

**Unrelated Note**: Unless I'm missing something,  the ReferenceDrawer instantiated in GetReferenceDrawer(..) could be reused for every instances, the same way Unity reuses the PropertyDrawer for multiple instances to avoid GC.