### PR TITLE
#24 add none option custom drawers

### DIFF
--- a/Editor/Drawers/CustomObjectDrawer.cs
+++ b/Editor/Drawers/CustomObjectDrawer.cs
@@ -94,6 +94,7 @@ namespace TNRD.Drawers
             else if (Event.button == 1 && positionWithoutThumb.Contains(Event.mousePosition))
             {
                 GenericMenu menu = new GenericMenu();
+                menu.AddItem(new GUIContent("Clear"), false, () => { DeletePressed?.Invoke(); });
                 menu.AddItem(new GUIContent("Properties..."), false, () => { PropertiesClicked?.Invoke(); });
                 menu.DropDown(position);
                 Event.Use();

--- a/Editor/Items/NoneDropdownItem.cs
+++ b/Editor/Items/NoneDropdownItem.cs
@@ -4,10 +4,9 @@ namespace TNRD.Items
 {
     public class NoneDropdownItem  : AdvancedDropdownItem, IDropdownItem
     {
-        private ReferenceMode mode => ReferenceMode.Raw;
         public NoneDropdownItem() : base("None") { }
 
-        ReferenceMode IDropdownItem.Mode => mode;
+        ReferenceMode IDropdownItem.Mode => ReferenceMode.Raw;
 
         public object GetValue()
         {

--- a/Editor/Items/NoneDropdownItem.cs
+++ b/Editor/Items/NoneDropdownItem.cs
@@ -1,0 +1,17 @@
+﻿using UnityEditor.IMGUI.Controls;
+
+namespace TNRD.Items
+{
+    public class NoneDropdownItem  : AdvancedDropdownItem, IDropdownItem
+    {
+        private ReferenceMode mode => ReferenceMode.Raw;
+        public NoneDropdownItem() : base("None") { }
+
+        ReferenceMode IDropdownItem.Mode => mode;
+
+        public object GetValue()
+        {
+            return default;
+        }
+    }
+}

--- a/Editor/Items/NoneDropdownItem.cs
+++ b/Editor/Items/NoneDropdownItem.cs
@@ -11,7 +11,7 @@ namespace TNRD.Items
 
         public object GetValue()
         {
-            return default;
+            return null;
         }
     }
 }

--- a/Editor/Items/NoneDropdownItem.cs.meta
+++ b/Editor/Items/NoneDropdownItem.cs.meta
@@ -1,0 +1,3 @@
+fileFormatVersion: 2
+guid: a7015062205d46cbb9cb01b0b88fff55
+timeCreated: 1657572673

--- a/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
+++ b/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
@@ -61,6 +61,7 @@ namespace TNRD.Utilities
                         (Comparison<AdvancedDropdownItem>)Sort, true
                     });
             }
+
             return item;
         }
 

--- a/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
+++ b/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
@@ -48,6 +48,11 @@ namespace TNRD.Utilities
                 .AddChild(new ClassesItemBuilder(interfaceType).Build())
                 .AddChild(new SceneItemBuilder(interfaceType, relevantScene).Build());
 
+            foreach (var dropdownItem in item.children)
+            {
+                dropdownItem.AddChild(new NoneDropdownItem());
+            }
+            
             if (canSort)
             {
                 sortChildrenMethod.Invoke(item,
@@ -56,12 +61,17 @@ namespace TNRD.Utilities
                         (Comparison<AdvancedDropdownItem>)Sort, true
                     });
             }
-
             return item;
         }
 
         private int Sort(AdvancedDropdownItem a, AdvancedDropdownItem b)
         {
+            // For aesthetic reasons. Always puts the None first
+            if (a is NoneDropdownItem)
+                return -1;
+            if (b is NoneDropdownItem)
+                return 1;
+            
             int childrenA = a.children.Count();
             int childrenB = b.children.Count();
 

--- a/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
+++ b/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
@@ -48,7 +48,7 @@ namespace TNRD.Utilities
                 .AddChild(new ClassesItemBuilder(interfaceType).Build())
                 .AddChild(new SceneItemBuilder(interfaceType, relevantScene).Build());
 
-            foreach (var dropdownItem in item.children)
+            foreach (AdvancedDropdownItem dropdownItem in item.children)
             {
                 dropdownItem.AddChild(new NoneDropdownItem());
             }


### PR DESCRIPTION
## Description
Adds a **None** option in **Assets**, **Classes** and **Scenes** Categories. 
This is done in `SerializableInterfaceAdvancedDropdown.cs`, but could've easily been done in every AdvancedDropdownItem Builder (e.g. `SceneItemBuilder`...). I would argue there's benefits in both methods. 

A side effect of adding a None option in every Category is that they all show they contain something. This changes the previous behaviour, but makes it so that the Categories always display in the same order. This makes using the Dropdown more intuitive and helps build muscle memory.

## Note
Also added a Clear context menu, but this was technically out of scope. Just really simple to add... :v

### Issue
This fixes #24 