### PR TITLE
Updated SerializableInterface.cs to use safe casting

### DIFF
--- a/Runtime/SerializableInterface.cs
+++ b/Runtime/SerializableInterface.cs
@@ -9,7 +9,7 @@ namespace TNRD
     /// </summary>
     /// <typeparam name="TInterface">The type of the interface you want to serialize</typeparam>
     [Serializable]
-    public class SerializableInterface<TInterface> : ISerializableInterface
+    public class SerializableInterface<TInterface> : ISerializableInterface where TInterface : class
     {
         [HideInInspector, SerializeField] private ReferenceMode mode = ReferenceMode.Unity;
         [HideInInspector, SerializeField] private UnityEngine.Object unityReference;
@@ -21,8 +21,8 @@ namespace TNRD
             {
                 return mode switch
                 {
-                    ReferenceMode.Raw => (TInterface)rawReference,
-                    ReferenceMode.Unity => (TInterface)(object)unityReference,
+                    ReferenceMode.Raw => rawReference as TInterface,
+                    ReferenceMode.Unity => (object)unityReference as TInterface,
                     _ => throw new ArgumentOutOfRangeException()
                 };
             }


### PR DESCRIPTION
## Description
Fixes #31.

This is a weird bug, because it only happens when the `ReferenceMode mode` variable is defaulted to `ReferenceMode.Unity`. A quick fix would have been to make it equal to `ReferenceMode.Raw`, but this implementation makes also a lot of sense. This is simply a safer way to cast. 

Adding the `where TInterface : class` also removes some warning about potential boxing.

## Note
Right now, while the fields are defaulted to `ReferenceMode.Unity`, elements in lists are not and will show `None (Mono Script)`. It seems Unity instantiates the class, but then changes all the fields to a default value.
![image](https://user-images.githubusercontent.com/62125329/178860677-7648123a-ca5b-4659-829a-fddf877fd54e.png)
This means that switching the order of the values in the enum would make `ReferenceMode.Unity` the default one, and apparently, it is true:

![image](https://user-images.githubusercontent.com/62125329/178861356-9c9cfd92-9f97-4755-90d6-15c93571ba70.png)
