### PR TITLE
ReferenceMode + AvoidDuplicateReferencesInArray

### DIFF
--- a/Editor/Drawers/RawReferenceDrawer.cs
+++ b/Editor/Drawers/RawReferenceDrawer.cs
@@ -94,12 +94,7 @@ namespace TNRD.Drawers
 
         private void AvoidDuplicateReferencesInArray()
         {
-            if (!IsPropertyInArray(Property)) 
-                return;
-            if (previousPropertyPath == null) 
-                return;
-            if (previousPropertyPath == Property.propertyPath) 
-                return;
+            if (!ShouldCheckProperty()) return;
 
             object currentReferenceValue = RawReferenceValue;
 
@@ -107,9 +102,19 @@ namespace TNRD.Drawers
                 return;
 
             if (previousReferenceValue == currentReferenceValue)
-                PropertyValue = CreateInstance(currentReferenceValue);
+            {
+                currentReferenceValue = CreateInstance(currentReferenceValue);
+                PropertyValue = currentReferenceValue;
+            }
 
             previousReferenceValue = currentReferenceValue;
+        }
+
+        private bool ShouldCheckProperty()
+        {
+            return IsPropertyInArray(Property) && 
+                   previousPropertyPath != null && 
+                   previousPropertyPath != Property.propertyPath;
         }
 
         private static bool IsPropertyInArray(SerializedProperty prop)

--- a/Editor/Drawers/RawReferenceDrawer.cs
+++ b/Editor/Drawers/RawReferenceDrawer.cs
@@ -94,7 +94,8 @@ namespace TNRD.Drawers
 
         private void AvoidDuplicateReferencesInArray()
         {
-            if (!ShouldCheckProperty()) return;
+            if (!ShouldCheckProperty()) 
+                return;
 
             object currentReferenceValue = RawReferenceValue;
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,7 @@ And when you click on the object selector button you will be shown a dropdown wi
 ![image](https://user-images.githubusercontent.com/5531467/164994604-15a0d060-72d1-440b-926b-883dd5f31955.png)
 
 As you can see you can select items from multiple locations:
-- Assets (Scriptable Objects that implement said interface)
+- Assets (Scriptable Objects and Prefabs that implement said interface)
 - Classes (custom classes that implement said interface)
 - Scene (objects in the scene that implement said interface)
 

--- a/Runtime/ReferenceMode.cs
+++ b/Runtime/ReferenceMode.cs
@@ -2,7 +2,7 @@
 {
     internal enum ReferenceMode
     {
-        Raw,
-        Unity
+        Unity,
+        Raw
     }
 }


### PR DESCRIPTION
## Description

- Changed the default value in ReferenceMode (see https://github.com/Thundernerd/Unity3D-SerializableInterface/pull/32#issue-1304095980 Note section)
- Fix AvoidDuplicateReferencesInArray: Line 110 would be called twice since currentReferenceValue was not reset to the new value.
- Changed documentation to reflect PRs