### PR TITLE
fix/caching drawers

### DIFF
--- a/Editor/Drawers/CustomObjectDrawer.cs
+++ b/Editor/Drawers/CustomObjectDrawer.cs
@@ -5,13 +5,13 @@ namespace TNRD.Drawers
 {
     public partial class CustomObjectDrawer
     {
-        public delegate void ButtonClickedDelegate(Rect position);
+        public delegate void ButtonClickedDelegate(Rect position, SerializedProperty property);
 
-        public delegate void ClickedDelegate();
+        public delegate void ClickedDelegate(SerializedProperty property);
 
-        public delegate void DeletePressedDelegate();
+        public delegate void DeletePressedDelegate(SerializedProperty property);
 
-        public delegate void PropertiesClickedDelegate();
+        public delegate void PropertiesClickedDelegate(SerializedProperty property);
 
         private bool isSelected;
 
@@ -21,18 +21,18 @@ namespace TNRD.Drawers
         public event ClickedDelegate Clicked;
         public event DeletePressedDelegate DeletePressed;
         public event PropertiesClickedDelegate PropertiesClicked;
-
-        public void OnGUI(Rect position, GUIContent label, GUIContent content)
+        
+        public void OnGUI(Rect position, GUIContent label, GUIContent content, SerializedProperty property)
         {
             Rect positionWithoutThumb = new Rect(position);
             positionWithoutThumb.xMax -= 20;
 
             position = DrawPrefixLabel(position, label);
             DrawObjectField(position, content);
-            DrawButton(position);
+            DrawButton(position, property);
 
-            HandleMouseDown(position, positionWithoutThumb);
-            HandleKeyDown();
+            HandleMouseDown(position, positionWithoutThumb, property);
+            HandleKeyDown(property);
         }
 
         private Rect DrawPrefixLabel(Rect position, GUIContent label)
@@ -66,7 +66,7 @@ namespace TNRD.Drawers
             }
         }
 
-        private void DrawButton(Rect position)
+        private void DrawButton(Rect position, SerializedProperty property)
         {
             Rect buttonRect = new Rect(position);
             buttonRect.yMin += 1;
@@ -76,11 +76,11 @@ namespace TNRD.Drawers
 
             if (GUI.Button(buttonRect, string.Empty, "objectFieldButton"))
             {
-                ButtonClicked?.Invoke(position);
+                ButtonClicked?.Invoke(position, property);
             }
         }
 
-        private void HandleMouseDown(Rect position, Rect positionWithoutThumb)
+        private void HandleMouseDown(Rect position, Rect positionWithoutThumb, SerializedProperty property)
         {
             if (Event.type != EventType.MouseDown)
                 return;
@@ -89,26 +89,26 @@ namespace TNRD.Drawers
             {
                 isSelected = positionWithoutThumb.Contains(Event.mousePosition);
                 ForceRepaintEditors();
-                Clicked?.Invoke();
+                Clicked?.Invoke(property);
             }
             else if (Event.button == 1 && positionWithoutThumb.Contains(Event.mousePosition))
             {
                 GenericMenu menu = new GenericMenu();
-                menu.AddItem(new GUIContent("Clear"), false, () => { DeletePressed?.Invoke(); });
-                menu.AddItem(new GUIContent("Properties..."), false, () => { PropertiesClicked?.Invoke(); });
+                menu.AddItem(new GUIContent("Clear"), false, () => { DeletePressed?.Invoke(property); });
+                menu.AddItem(new GUIContent("Properties..."), false, () => { PropertiesClicked?.Invoke(property); });
                 menu.DropDown(position);
                 Event.Use();
             }
         }
 
-        private void HandleKeyDown()
+        private void HandleKeyDown(SerializedProperty property)
         {
             if (!isSelected)
                 return;
 
             if (Event.type == EventType.KeyDown && Event.keyCode == KeyCode.Delete)
             {
-                DeletePressed?.Invoke();
+                DeletePressed?.Invoke(property);
             }
         }
     }

--- a/Editor/Drawers/RawReferenceDrawer.cs
+++ b/Editor/Drawers/RawReferenceDrawer.cs
@@ -45,7 +45,7 @@ namespace TNRD.Drawers
                 ? EditorGUIUtility.ObjectContent((MonoScript)null, typeof(MonoScript))
                 : new GUIContent(rawReferenceValue.GetType().Name, IconUtility.ScriptIcon);
 
-            CustomObjectDrawer.OnGUI(objectFieldRect, label, content);
+            CustomObjectDrawer.OnGUI(objectFieldRect, label, content, Property);
 
             HandleDragAndDrop(objectFieldRect);
 
@@ -79,13 +79,13 @@ namespace TNRD.Drawers
             EditorGUI.DrawRect(line, Styles.LineColor);
         }
 
-        protected override void PingObject()
+        protected override void PingObject(SerializedProperty property)
         {
             // No support for pinging raw objects for now (I guess this would ping the MonoScript?)
         }
 
         /// <inheritdoc />
-        protected override void OnPropertiesClicked()
+        protected override void OnPropertiesClicked(SerializedProperty property)
         {
             if (RawReferenceValue == null)
                 return;

--- a/Editor/Drawers/ReferenceDrawer.cs
+++ b/Editor/Drawers/ReferenceDrawer.cs
@@ -27,69 +27,28 @@ namespace TNRD.Drawers
         protected SerializedProperty Property { get; private set; }
         protected Type GenericType { get; private set; }
 
-        protected SerializedProperty ReferenceModeProperty => Property.FindPropertyRelative("mode");
-        protected SerializedProperty RawReferenceProperty => Property.FindPropertyRelative("rawReference");
-        protected SerializedProperty UnityReferenceProperty => Property.FindPropertyRelative("unityReference");
+        protected SerializedProperty ReferenceModeProperty => Property.ReferenceModeProperty();
+        protected SerializedProperty RawReferenceProperty => Property.RawReferenceProperty();
+        protected SerializedProperty UnityReferenceProperty => Property.UnityReferenceProperty();
 
         protected FieldInfo FieldInfo { get; private set; }
 
         protected ReferenceMode ModeValue
         {
-            get => (ReferenceMode)ReferenceModeProperty.enumValueIndex;
-            set => ReferenceModeProperty.enumValueIndex = (int)value;
+            get => GetModeValue(Property);
+            set => SetModeValue(Property, value);
         }
 
         protected object RawReferenceValue
         {
-            get
-            {
-#if UNITY_2021_1_OR_NEWER
-                return RawReferenceProperty.managedReferenceValue;
-#else
-                ISerializableInterface instance =
-                    (ISerializableInterface)FieldInfo.GetValue(Property.serializedObject.targetObject);
-                return instance.GetRawReference();
-#endif
-            }
-            set
-            {
-#if UNITY_2021_1_OR_NEWER
-                RawReferenceProperty.managedReferenceValue = value;
-#else
-                FieldInfo.SetValue(Property.serializedObject.targetObject, value);
-#endif
-            }
+            get => GetRawReferenceValue(Property);
+            set => SetRawReferenceValue(Property, value);
         }
 
         protected object PropertyValue
         {
-            get
-            {
-                return ModeValue switch
-                {
-                    ReferenceMode.Raw => RawReferenceValue,
-                    ReferenceMode.Unity => UnityReferenceProperty.objectReferenceValue,
-                    _ => throw new ArgumentOutOfRangeException()
-                };
-            }
-            set
-            {
-                switch (ModeValue)
-                {
-                    case ReferenceMode.Raw:
-                        RawReferenceValue = value;
-                        UnityReferenceProperty.objectReferenceValue = null;
-                        break;
-                    case ReferenceMode.Unity:
-                        UnityReferenceProperty.objectReferenceValue = GetUnityObject((Object)value);
-                        RawReferenceValue = null;
-                        break;
-                    default:
-                        throw new ArgumentOutOfRangeException();
-                }
-
-                Property.serializedObject.ApplyModifiedProperties();
-            }
+            get => GetPropertyValue(Property);
+            set => SetPropertyValue(Property, value);
         }
 
         protected ReferenceDrawer()
@@ -247,5 +206,74 @@ namespace TNRD.Drawers
         }
 
         protected abstract void PingObject();
+
+        protected ReferenceMode GetModeValue(SerializedProperty property)
+        {
+            return (ReferenceMode)property.ReferenceModeProperty().enumValueIndex;
+        }
+
+        protected void SetModeValue(SerializedProperty property, ReferenceMode mode)
+        {
+            property.ReferenceModeProperty().enumValueIndex = (int)mode;
+        }
+
+        protected object GetRawReferenceValue(SerializedProperty property)
+        {
+#if UNITY_2021_1_OR_NEWER
+            return property.RawReferenceProperty().managedReferenceValue;
+#else
+                ISerializableInterface instance =
+                    (ISerializableInterface)FieldInfo.GetValue(property.serializedObject.targetObject);
+                return instance.GetRawReference();
+#endif
+        }
+
+        protected void SetRawReferenceValue(SerializedProperty property, object value)
+        {
+#if UNITY_2021_1_OR_NEWER
+            property.RawReferenceProperty().managedReferenceValue = value;
+#else
+            FieldInfo.SetValue(property.serializedObject.targetObject, value);
+#endif
+        }
+
+        protected Object GetUnityReferenceValue(SerializedProperty property)
+        {
+            return property.UnityReferenceProperty().objectReferenceValue;
+        }
+
+        protected void SetUnityReferenceValue(SerializedProperty property, object value)
+        {
+            property.UnityReferenceProperty().objectReferenceValue = GetUnityObject((Object)value);
+        }
+
+        protected object GetPropertyValue(SerializedProperty property)
+        {
+            return GetModeValue(property) switch
+            {
+                ReferenceMode.Raw => GetRawReferenceValue(property),
+                ReferenceMode.Unity => GetUnityReferenceValue(property),
+                _ => throw new ArgumentOutOfRangeException()
+            };
+        }
+
+        protected void SetPropertyValue(SerializedProperty property, object value)
+        {
+            switch (GetModeValue(property))
+            {
+                case ReferenceMode.Unity:
+                    SetUnityReferenceValue(property, value);
+                    SetRawReferenceValue(property, null);
+                    break;
+                case ReferenceMode.Raw:
+                    SetRawReferenceValue(property, value);
+                    SetUnityReferenceValue(property, null);
+                    break;
+                default:
+                    throw new ArgumentOutOfRangeException();
+            }
+
+            property.serializedObject.ApplyModifiedProperties();
+        }
     }
 }

--- a/Editor/Drawers/ReferenceDrawer.cs
+++ b/Editor/Drawers/ReferenceDrawer.cs
@@ -67,18 +67,18 @@ namespace TNRD.Drawers
             FieldInfo = fieldInfo;
         }
 
-        private void OnButtonClicked(Rect position)
+        private void OnButtonClicked(Rect position, SerializedProperty property)
         {
             AdvancedDropdownState state = new AdvancedDropdownState();
             SerializableInterfaceAdvancedDropdown dropdown =
-                new SerializableInterfaceAdvancedDropdown(state, GenericType, GetRelevantScene());
+                new SerializableInterfaceAdvancedDropdown(state, GenericType, GetRelevantScene(property), property);
             dropdown.ItemSelectedEvent += OnItemSelected;
             dropdown.Show(position);
         }
 
-        private Scene? GetRelevantScene()
+        private static Scene? GetRelevantScene(SerializedProperty property)
         {
-            Object target = Property.serializedObject.targetObject;
+            Object target = property.serializedObject.targetObject;
 
             if (target is ScriptableObject)
                 return null;
@@ -90,30 +90,30 @@ namespace TNRD.Drawers
             return null;
         }
 
-        private void OnClicked()
+        private void OnClicked(SerializedProperty property)
         {
-            PingObject();
+            PingObject(property);
         }
 
-        private void OnDeletePressed()
+        private void OnDeletePressed(SerializedProperty property)
         {
-            ModeValue = default;
-            PropertyValue = null;
+            SetModeValue(property, default);
+            SetPropertyValue(property, null);
         }
 
-        private void OnItemSelected(ReferenceMode mode, object reference)
+        private void OnItemSelected(SerializedProperty property, ReferenceMode mode, object reference)
         {
-            ModeValue = mode;
-            PropertyValue = reference;
+            SetModeValue(property, mode);
+            SetPropertyValue(property, reference);
         }
 
-        protected abstract void OnPropertiesClicked();
+        protected abstract void OnPropertiesClicked(SerializedProperty property);
 
         protected void HandleDragAndDrop(Rect position)
         {
             if (!position.Contains(Event.current.mousePosition))
                 return;
-            
+
             if (Event.current.type == EventType.DragPerform)
             {
                 HandleDragUpdated();
@@ -200,12 +200,12 @@ namespace TNRD.Drawers
 
         private Object GetUnityObject(Object objectReference)
         {
-            if(objectReference is GameObject gameObject)
+            if (objectReference is GameObject gameObject)
                 return gameObject.GetComponent(GenericType);
             return objectReference;
         }
 
-        protected abstract void PingObject();
+        protected abstract void PingObject(SerializedProperty property);
 
         protected ReferenceMode GetModeValue(SerializedProperty property)
         {

--- a/Editor/Drawers/UnityReferenceDrawer.cs
+++ b/Editor/Drawers/UnityReferenceDrawer.cs
@@ -27,18 +27,18 @@ namespace TNRD.Drawers
             Object unityReference = UnityReferenceProperty.objectReferenceValue;
             Type referenceType = unityReference == null ? typeof(Object) : unityReference.GetType();
             GUIContent objectContent = EditorGUIUtility.ObjectContent(unityReference, referenceType);
-            CustomObjectDrawer.OnGUI(position, label, objectContent);
+            CustomObjectDrawer.OnGUI(position, label, objectContent, Property);
             HandleDragAndDrop(position);
         }
 
-        protected override void PingObject()
+        protected override void PingObject(SerializedProperty property)
         {
-            EditorGUIUtility.PingObject((Object)PropertyValue);
+            EditorGUIUtility.PingObject((Object)GetPropertyValue(property));
         }
 
-        protected override void OnPropertiesClicked()
+        protected override void OnPropertiesClicked(SerializedProperty property)
         {
-            PropertyEditorUtility.Show(UnityReferenceProperty.objectReferenceValue);
+            PropertyEditorUtility.Show(property.UnityReferenceProperty().objectReferenceValue);
         }
     }
 }

--- a/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
+++ b/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
@@ -3,6 +3,7 @@ using System.Linq;
 using System.Reflection;
 using TNRD.Builders;
 using TNRD.Items;
+using UnityEditor;
 using UnityEditor.IMGUI.Controls;
 using UnityEngine;
 using UnityEngine.Assertions;
@@ -16,8 +17,9 @@ namespace TNRD.Utilities
         private readonly MethodInfo sortChildrenMethod;
         private readonly bool canSort;
         private readonly Scene? relevantScene;
+        private readonly SerializedProperty property;
 
-        public delegate void ItemSelectedDelegate(ReferenceMode mode, object reference);
+        public delegate void ItemSelectedDelegate(SerializedProperty property, ReferenceMode mode, object reference);
 
         public event ItemSelectedDelegate ItemSelectedEvent; // Suffixed with Event because of the override
 
@@ -25,7 +27,8 @@ namespace TNRD.Utilities
         public SerializableInterfaceAdvancedDropdown(
             AdvancedDropdownState state,
             Type interfaceType,
-            Scene? relevantScene
+            Scene? relevantScene,
+            SerializedProperty property
         )
             : base(state)
         {
@@ -38,6 +41,7 @@ namespace TNRD.Utilities
             minimumSize = new Vector2(0, 300);
             this.interfaceType = interfaceType;
             this.relevantScene = relevantScene;
+            this.property = property;
         }
 
         /// <inheritdoc />
@@ -52,7 +56,7 @@ namespace TNRD.Utilities
             {
                 dropdownItem.AddChild(new NoneDropdownItem());
             }
-            
+
             if (canSort)
             {
                 sortChildrenMethod.Invoke(item,
@@ -72,7 +76,7 @@ namespace TNRD.Utilities
                 return -1;
             if (b is NoneDropdownItem)
                 return 1;
-            
+
             int childrenA = a.children.Count();
             int childrenB = b.children.Count();
 
@@ -90,7 +94,7 @@ namespace TNRD.Utilities
         {
             if (item is IDropdownItem dropdownItem)
             {
-                ItemSelectedEvent?.Invoke(dropdownItem.Mode, dropdownItem.GetValue());
+                ItemSelectedEvent?.Invoke(property, dropdownItem.Mode, dropdownItem.GetValue());
             }
         }
     }

--- a/Editor/Utilities/SerializedPropertyExtensions.cs
+++ b/Editor/Utilities/SerializedPropertyExtensions.cs
@@ -1,0 +1,22 @@
+﻿using UnityEditor;
+
+namespace TNRD.Utilities
+{
+    internal static class SerializedPropertyExtensions
+    {
+        public static SerializedProperty ReferenceModeProperty(this SerializedProperty property)
+        {
+            return property.FindPropertyRelative("mode");
+        }
+
+        public static SerializedProperty RawReferenceProperty(this SerializedProperty property)
+        {
+            return property.FindPropertyRelative("rawReference");
+        }
+
+        public static SerializedProperty UnityReferenceProperty(this SerializedProperty property)
+        {
+            return property.FindPropertyRelative("unityReference");
+        }
+    }
+}

--- a/Editor/Utilities/SerializedPropertyExtensions.cs.meta
+++ b/Editor/Utilities/SerializedPropertyExtensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 8bfd876a31f9470b802c64d4f1a8dd37
+timeCreated: 1658567318


### PR DESCRIPTION
## Proposed changes

I've recently introduced caching of the reference drawers which broke support for collections. This fix passes the appropriate `SerializedProperty` along so that this can be used to determine the correct values.

## Types of changes

_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming)
- [ ] Build related changes (workflow changes)
- [ ] Documentation Update (readme, changelog)
- [ ] Other, please describe:


## Issue
#40 

## What is the current behavior?
When removing an item from a collection it will always remove the last item, instead of the selected item.

## What is the new behavior?
When removing an item it now removes the selected item.

## Checklist

_Put an `x` in the boxes that apply._

- [x] The code compiles
- [x] I have tested that this doesn't break existing code (unless it is an explicit breaking change)
- [x] I have tested that the (new) functionality/fix works as intended
- [x] I have added necessary documentation (if appropriate)
