### PR TITLE
feature/getting value shorthand

### DIFF
--- a/Runtime/Extensions.cs
+++ b/Runtime/Extensions.cs
@@ -1,0 +1,45 @@
+﻿using System.Collections.Generic;
+
+namespace TNRD
+{
+    public static class Extensions
+    {
+        /// <summary>
+        /// Checks to see if the containing value is valid and returns it through the out parameter if so
+        /// </summary>
+        /// <param name="serializableInterface"></param>
+        /// <param name="value">The containing value, if valid</param>
+        /// <returns>True if the containing value is valid, false if not</returns>
+        public static bool IsDefined<TInterface>(
+            this SerializableInterface<TInterface> serializableInterface,
+            out TInterface value
+        )
+            where TInterface : class
+        {
+            if (serializableInterface == null)
+            {
+                value = default;
+                return false;
+            }
+
+            if (EqualityComparer<TInterface>.Default.Equals(serializableInterface.Value, default))
+            {
+                value = default;
+                return false;
+            }
+
+            value = serializableInterface.Value;
+            return true;
+        }
+        
+        /// <inheritdoc cref="IsDefined{TInterface}"/>
+        public static bool TryGetValue<TInterface>(
+            this SerializableInterface<TInterface> serializableInterface,
+            out TInterface value
+        )
+            where TInterface : class
+        {
+            return IsDefined(serializableInterface, out value);
+        }
+    }
+}

--- a/Runtime/Extensions.cs.meta
+++ b/Runtime/Extensions.cs.meta
@@ -1,0 +1,3 @@
+﻿fileFormatVersion: 2
+guid: 77acf133582b451fa1cea3bb60b48dc6
+timeCreated: 1659443598


### PR DESCRIPTION
## Proposed changes

Added a way for doing null checks and getting the contained value with two shorthands:
- TryGetValue(out value)
- IsDefined(out value)

TryGetValue points to IsDefined so they are functionally the same, just different names.

## Types of changes

_Put an `x` in the boxes that apply._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming)
- [ ] Build related changes (workflow changes)
- [ ] Documentation Update (readme, changelog)
- [ ] Other, please describe:


## Issue

#33 

## What is the current behavior?
Currently you will have to do manual checks on the wrapper, and then on the contained value.

## What is the new behavior?
The new behaviour supports calling `IsDefined(out value);` or `TryGetValue(out value);` as shorthands for the current behaviour.

## Checklist

_Put an `x` in the boxes that apply._

- [x] The code compiles
- [x] I have tested that this doesn't break existing code (unless it is an explicit breaking change)
- [x] I have tested that the (new) functionality/fix works as intended
- [x] I have added necessary documentation (if appropriate)