### PR TITLE
Improve usage with Arrays and Lists

### DIFF
--- a/Editor/Drawers/CustomObjectDrawer.cs
+++ b/Editor/Drawers/CustomObjectDrawer.cs
@@ -89,7 +89,10 @@ namespace TNRD.Drawers
             {
                 isSelected = positionWithoutThumb.Contains(Event.mousePosition);
                 ForceRepaintEditors();
-                Clicked?.Invoke(property);
+                if (isSelected)
+                {
+                    Clicked?.Invoke(property);
+                }
             }
             else if (Event.button == 1 && positionWithoutThumb.Contains(Event.mousePosition))
             {

--- a/Runtime/Extensions.cs
+++ b/Runtime/Extensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Collections.Generic;
+using System.Linq;
 
 namespace TNRD
 {
@@ -41,5 +42,22 @@ namespace TNRD
         {
             return IsDefined(serializableInterface, out value);
         }
+
+        /// <summary>
+        /// Convert a IEnumerable of Interfaces to a List of SerializableInterfaces
+        /// </summary>
+        public static List<SerializableInterface<T>> ToSerializableInterfaceList<T>(this IEnumerable<T> list) where T : class
+        {
+            return list.Select(e => new SerializableInterface<T>(e) ).ToList();
+        }
+
+         /// <summary>
+        /// Convert a IEnumerable of Interfaces to an Array of SerializableInterfaces
+        /// </summary>
+        public static SerializableInterface<T>[] ToSerializableInterfaceArray<T>(this IEnumerable<T> list) where T : class
+        {
+            return list.Select(e => new SerializableInterface<T>(e)).ToArray();
+        }
+
     }
 }

--- a/Runtime/Extensions.cs
+++ b/Runtime/Extensions.cs
@@ -48,7 +48,7 @@ namespace TNRD
         /// </summary>
         public static List<SerializableInterface<T>> ToSerializableInterfaceList<T>(this IEnumerable<T> list) where T : class
         {
-            return list.Select(e => new SerializableInterface<T>(e) ).ToList();
+            return list.Select(e => new SerializableInterface<T>(e)).ToList();
         }
 
          /// <summary>

--- a/Runtime/Extensions.cs
+++ b/Runtime/Extensions.cs
@@ -58,6 +58,5 @@ namespace TNRD
         {
             return list.Select(e => new SerializableInterface<T>(e)).ToArray();
         }
-
     }
 }

--- a/Runtime/SerializableInterface.cs
+++ b/Runtime/SerializableInterface.cs
@@ -23,6 +23,7 @@ namespace TNRD
         {
             Value = value;
         }
+
         public TInterface Value
         {
             get

--- a/Runtime/SerializableInterface.cs
+++ b/Runtime/SerializableInterface.cs
@@ -17,14 +17,12 @@ namespace TNRD
 
         public SerializableInterface()
         {
-
         }
+
         public SerializableInterface(TInterface value)
         {
             Value = value;
         }
-
-
         public TInterface Value
         {
             get

--- a/Runtime/SerializableInterface.cs
+++ b/Runtime/SerializableInterface.cs
@@ -15,6 +15,16 @@ namespace TNRD
         [HideInInspector, SerializeField] private UnityEngine.Object unityReference;
         [SerializeReference, UsedImplicitly] private object rawReference;
 
+        public SerializableInterface()
+        {
+
+        }
+        public SerializableInterface(TInterface value)
+        {
+            Value = value;
+        }
+
+
         public TInterface Value
         {
             get


### PR DESCRIPTION
## Proposed changes

Make the SerializableInterface work better as an Array or List. Added Extensions Methods to convert an Array/List of Interfaces to a Array/List of SerializableInterface.
Fixed and issue that prevented to set different Values to a Array/List in the Unity Inspector.

## Types of changes

_Put an `x` in the boxes that apply._

- [x] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming)
- [ ] Build related changes (workflow changes)
- [ ] Documentation Update (readme, changelog)
- [ ] Other, please describe:


## Issue
None

## What is the current behavior?
When having an Array/List of SerializableInterface in the Unity Editor and setting on Element with the Dropdown, all Elements were set to the Selection of the Dropdown.
There was no way to convert a Array/List of Interface to a Array/List of SerializableInterface which would be usefull when populating a SerializableInterface Array/List from an Editor Tool.

## What is the new behavior?
When having an Array/List of SerializableInterface in the Unity Editor and setting on Element with the Dropdown, only the selected Element is set to the Selection of the Dropdown
There is a Constructor to create a SerializableInterface from an Interface and also extensions to create Array/Lists
## Checklist

_Put an `x` in the boxes that apply._

- [x] The code compiles
- [x] I have tested that this doesn't break existing code (unless it is an explicit breaking change)
- [x] I have tested that the (new) functionality/fix works as intended
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I'm happy to discuss my changes
