### PR TITLE
Added [ClassesOnly] attribute for usage in large projects, dramatically improving dropdown opening time

### DIFF
--- a/Editor/Attributes.meta
+++ b/Editor/Attributes.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: beb82a782d0e3f34f9288d36e70fcbbd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Attributes/ClassesOnlyAttribute.cs
+++ b/Editor/Attributes/ClassesOnlyAttribute.cs
@@ -1,0 +1,8 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace TNRD
+{
+    public class ClassesOnlyAttribute : PropertyAttribute { }
+}

--- a/Editor/Attributes/ClassesOnlyAttribute.cs
+++ b/Editor/Attributes/ClassesOnlyAttribute.cs
@@ -4,5 +4,6 @@ using UnityEngine;
 
 namespace TNRD
 {
+    /// <summary>An attribute to use when you want to exclude non-raw references in the reference picker.</summary>
     public class ClassesOnlyAttribute : PropertyAttribute { }
 }

--- a/Editor/Attributes/ClassesOnlyAttribute.cs.meta
+++ b/Editor/Attributes/ClassesOnlyAttribute.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 93d9f96b32dbd774e9f05dc7f675d338
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Editor/Drawers/ReferenceDrawer.cs
+++ b/Editor/Drawers/ReferenceDrawer.cs
@@ -71,7 +71,7 @@ namespace TNRD.Drawers
         {
             AdvancedDropdownState state = new AdvancedDropdownState();
             SerializableInterfaceAdvancedDropdown dropdown =
-                new SerializableInterfaceAdvancedDropdown(state, GenericType, GetRelevantScene(property), property);
+                new SerializableInterfaceAdvancedDropdown(state, GenericType, GetRelevantScene(property), property, FieldInfo.GetCustomAttribute<ClassesOnlyAttribute>() != null);
             dropdown.ItemSelectedEvent += OnItemSelected;
             dropdown.Show(position);
         }

--- a/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
+++ b/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
@@ -16,6 +16,7 @@ namespace TNRD.Utilities
         private readonly Type interfaceType;
         private readonly MethodInfo sortChildrenMethod;
         private readonly bool canSort;
+        private readonly bool rawReferencesOnly;
         private readonly Scene? relevantScene;
         private readonly SerializedProperty property;
 
@@ -28,7 +29,8 @@ namespace TNRD.Utilities
             AdvancedDropdownState state,
             Type interfaceType,
             Scene? relevantScene,
-            SerializedProperty property
+            SerializedProperty property,
+            bool classesOnly
         )
             : base(state)
         {
@@ -42,15 +44,21 @@ namespace TNRD.Utilities
             this.interfaceType = interfaceType;
             this.relevantScene = relevantScene;
             this.property = property;
+            this.rawReferencesOnly = classesOnly;
         }
 
         /// <inheritdoc />
         protected override AdvancedDropdownItem BuildRoot()
         {
-            AdvancedDropdownItemWrapper item = new AdvancedDropdownItemWrapper(interfaceType.Name)
-                .AddChild(new AssetsItemBuilder(interfaceType).Build())
-                .AddChild(new ClassesItemBuilder(interfaceType).Build())
-                .AddChild(new SceneItemBuilder(interfaceType, relevantScene).Build());
+            AdvancedDropdownItemWrapper item = new AdvancedDropdownItemWrapper(interfaceType.Name);
+
+            item.AddChild(new ClassesItemBuilder(interfaceType).Build());
+
+            if (!rawReferencesOnly)
+            {
+                item.AddChild(new AssetsItemBuilder(interfaceType).Build());
+                item.AddChild(new SceneItemBuilder(interfaceType, relevantScene).Build());
+            }
 
             foreach (AdvancedDropdownItem dropdownItem in item.children)
             {

--- a/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
+++ b/Editor/Utilities/SerializableInterfaceAdvancedDropdown.cs
@@ -16,7 +16,7 @@ namespace TNRD.Utilities
         private readonly Type interfaceType;
         private readonly MethodInfo sortChildrenMethod;
         private readonly bool canSort;
-        private readonly bool rawReferencesOnly;
+        private readonly bool classesOnly;
         private readonly Scene? relevantScene;
         private readonly SerializedProperty property;
 
@@ -44,7 +44,7 @@ namespace TNRD.Utilities
             this.interfaceType = interfaceType;
             this.relevantScene = relevantScene;
             this.property = property;
-            this.rawReferencesOnly = classesOnly;
+            this.classesOnly = classesOnly;
         }
 
         /// <inheritdoc />
@@ -54,7 +54,7 @@ namespace TNRD.Utilities
 
             item.AddChild(new ClassesItemBuilder(interfaceType).Build());
 
-            if (!rawReferencesOnly)
+            if (!classesOnly)
             {
                 item.AddChild(new AssetsItemBuilder(interfaceType).Build());
                 item.AddChild(new SceneItemBuilder(interfaceType, relevantScene).Build());


### PR DESCRIPTION
## Proposed changes
In larger projects (or projects with many assets) the reference picker takes very long to open due to scanning all assets. In the projects I've used SerializableInterface in we're talking around 3 or 4 seconds, which is painful and frankly unbearable to the extent that I had to make this.

This PR adds a [ClassesOnly] attribute that simply excludes the `AssetsItemBuilder` and `SceneItemBuilder` from the dropdown, **dramatically** improving the performance in projects with many assets. It's an optional attribute, so it doesn't really affect normal usage. It also doesn't prevent assets etc. from being dragged to the field like normal. It only affects the dropdown.

## Types of changes

_Put an `x` in the boxes that apply._

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming)
- [ ] Build related changes (workflow changes)
- [ ] Documentation Update (readme, changelog)
- [ ] Other, please describe:

## What is the current behavior?
In projects with many assets the dropdown takes multiple seconds to open, making normal usage a pain.

## What is the new behavior?
Ability to add a [ClassesOnly] attribute which then only includes the ClassesItemBuilder in the dropdown, drastically improving performance. It is handy if you know that you want to create an instance of a class rather than reference an existing object anyway.

## Checklist

_Put an `x` in the boxes that apply._

- [x] The code compiles
- [x] I have tested that this doesn't break existing code (unless it is an explicit breaking change)
- [x] I have tested that the (new) functionality/fix works as intended
- [x] I have added necessary documentation (if appropriate)

## Further comments
An alternative could be adding settings for which reference types are included in the dropdown by default, as suggested here: https://github.com/Thundernerd/Unity3D-SerializableInterface/issues/48#issuecomment-1801480503
I would personally prefer this as it would mean that you wouldn't have to touch the code at all to maintain usable performance even in larger projects.
