### PR TITLE
feat: instantiation support

### DIFF
--- a/Runtime/Extensions.cs
+++ b/Runtime/Extensions.cs
@@ -110,17 +110,10 @@ namespace TNRD
 
         private static TInterface GetInterfaceReference<TInterface>(Object instantiatedObject) where TInterface : class
         {
-            if (instantiatedObject is GameObject)
-            {
-                GameObject go = (GameObject)instantiatedObject;
-                if (!go.TryGetComponent(out TInterface tInterface)) return null;
-                return tInterface;
-            }
-            else
-            {
-                if (instantiatedObject is TInterface is false) return null;
-                return instantiatedObject as TInterface;
-            }
+            if (instantiatedObject is GameObject gameObject)
+                return gameObject.TryGetComponent(out TInterface component) ? component : null;
+
+            return instantiatedObject as TInterface;
         }
     }
 }

--- a/Runtime/Extensions.cs
+++ b/Runtime/Extensions.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Linq;
+using UnityEngine;
 
 namespace TNRD
 {
@@ -57,6 +58,77 @@ namespace TNRD
         public static SerializableInterface<T>[] ToSerializableInterfaceArray<T>(this IEnumerable<T> list) where T : class
         {
             return list.Select(e => new SerializableInterface<T>(e)).ToArray();
+        }
+
+        public static TInterface Instantiate<TInterface>(this SerializableInterface<TInterface> serializableInterface) where TInterface : class
+        {
+            if (!serializableInterface.TryGetObject(out Object unityObject)) 
+            {
+                throw new System.Exception($"Cannot instantiate {serializableInterface} because it's has no reference of type UnityEngine.Object");
+            }
+
+            Object instantiatedObject = Object.Instantiate(unityObject);
+            
+            if(instantiatedObject is GameObject)
+            {
+                GameObject go = (GameObject)instantiatedObject;
+                return go.GetComponent<TInterface>();
+            }
+            else
+            {
+                return instantiatedObject as TInterface;
+            }
+        }
+
+        public static TInterface Instantiate<TInterface>(this SerializableInterface<TInterface> serializableInterface, Transform parent) where TInterface : class
+        {
+            if (!serializableInterface.TryGetObject(out Object unityObject))
+            {
+                throw new System.Exception($"Cannot instantiate {serializableInterface} because it's has no reference of type UnityEngine.Object");
+            }
+
+            Object instantiatedObject = Object.Instantiate(unityObject, parent);
+
+            return GetInterfaceReference<TInterface>(instantiatedObject);
+        }        
+
+        public static TInterface Instantiate<TInterface>(this SerializableInterface<TInterface> serializableInterface, Vector3 position, Quaternion rotation) where TInterface : class
+        {
+            if (!serializableInterface.TryGetObject(out Object unityObject))
+            {
+                throw new System.Exception($"Cannot instantiate {serializableInterface} because it's has no reference of type UnityEngine.Object");
+            }
+
+            Object instantiatedObject = Object.Instantiate(unityObject, position, rotation);
+
+            return GetInterfaceReference<TInterface>(instantiatedObject);
+        }
+
+        public static TInterface Instantiate<TInterface>(this SerializableInterface<TInterface> serializableInterface, Vector3 position, Quaternion rotation, Transform parent) where TInterface : class
+        {
+            if (!serializableInterface.TryGetObject(out Object unityObject))
+            {
+                throw new System.Exception($"Cannot instantiate {serializableInterface} because it's has no reference of type UnityEngine.Object");
+            }
+
+            Object instantiatedObject = Object.Instantiate(unityObject, position, rotation, parent);
+
+            return GetInterfaceReference<TInterface>(instantiatedObject);
+        }
+
+        private static TInterface GetInterfaceReference<TInterface>(Object instantiatedObject) where TInterface : class
+        {
+            if (instantiatedObject is GameObject)
+            {
+                GameObject go = (GameObject)instantiatedObject;
+                if (!go.TryGetComponent(out TInterface tInterface)) return null;
+                return tInterface;
+            }
+            else
+            {
+                if (instantiatedObject is TInterface is false) return null;
+                return instantiatedObject as TInterface;
+            }
         }
     }
 }

--- a/Runtime/Extensions.cs
+++ b/Runtime/Extensions.cs
@@ -68,16 +68,8 @@ namespace TNRD
             }
 
             Object instantiatedObject = Object.Instantiate(unityObject);
-            
-            if(instantiatedObject is GameObject)
-            {
-                GameObject go = (GameObject)instantiatedObject;
-                return go.GetComponent<TInterface>();
-            }
-            else
-            {
-                return instantiatedObject as TInterface;
-            }
+
+            return GetInterfaceReference<TInterface>(instantiatedObject);
         }
 
         public static TInterface Instantiate<TInterface>(this SerializableInterface<TInterface> serializableInterface, Transform parent) where TInterface : class

--- a/Runtime/SerializableInterface.cs
+++ b/Runtime/SerializableInterface.cs
@@ -57,5 +57,14 @@ namespace TNRD
         {
             return rawReference;
         }
+
+        public bool TryGetObject(out UnityEngine.Object unityObject)
+        {
+            unityObject = null;
+            if (mode != ReferenceMode.Unity) return false;
+
+            unityObject = unityReference;
+            return true;
+        }
     }
 }


### PR DESCRIPTION
## Proposed changes

I was struggling to find a way to instantiate a referenced `Object`. I created some extension methods that allow you to instantiate the referenced `Object` and return the interface.

## Types of changes

- [ ] Bugfix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactoring (no functional changes, no api changes)
- [ ] Code style update (formatting, renaming)
- [ ] Build related changes (workflow changes)
- [ ] Documentation Update (readme, changelog)
- [ ] Other, please describe:


## Issue
[Link](https://github.com/Thundernerd/Unity3D-SerializableInterface/issues/60)

## What is the current behavior?
Cannot instantiate referenced `Object`

## What is the new behavior?
Added support for instantiating `Object`s

## Checklist

- [x] The code compiles
- [x] I have tested that this doesn't break existing code (unless it is an explicit breaking change)
- [ ] I have tested that the (new) functionality/fix works as intended
- [ ] I have added necessary documentation (if appropriate)

## Further comments

I'm pretty sure there may be additional safety checks required for edge cases.
